### PR TITLE
fix: Escape markdown control characters in uploaded filenames

### DIFF
--- a/internal/routes.go
+++ b/internal/routes.go
@@ -46,6 +46,18 @@ var allowedFileExtensions = map[string]bool{
 // maxFileSize is the maximum allowed file size (10 MB)
 const maxFileSize = 10 << 20
 
+// escapeMarkdown escapes markdown control characters in a string to prevent injection
+func escapeMarkdown(s string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`[`, `\[`,
+		`]`, `\]`,
+		`(`, `\(`,
+		`)`, `\)`,
+	)
+	return replacer.Replace(s)
+}
+
 // sanitizeFilename removes path traversal attempts and ensures a safe base filename
 func sanitizeFilename(filename string) string {
 	// Get only the base name (removes any path components such as "..", "/" and "\")
@@ -340,7 +352,7 @@ func (a *App) submitRoute(c *gin.Context) {
 					_ = os.Remove(filePath)
 					continue
 				}
-				message += "[" + dbFile.Name + "](" + a.config.URL + "/file/" + url.QueryEscape(dbFile.Name) + "?id=" + dbFile.UUID + ")"
+				message += "[" + escapeMarkdown(dbFile.Name) + "](" + a.config.URL + "/file/" + url.QueryEscape(dbFile.Name) + "?id=" + dbFile.UUID + ")"
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Filenames containing markdown syntax characters (`[`, `]`, `(`, `)`) could break out of the link syntax when embedded in report messages
- An attacker could inject arbitrary links replacing legitimate download links, enabling phishing attacks against administrators
- Adds `escapeMarkdown()` helper that escapes markdown control characters before embedding filenames in link syntax

## Test plan
- [ ] Upload a file named `example.txt](https://evil.com) [t` and verify the rendered report shows the correct download link, not a link to `evil.com`
- [ ] Upload files with normal names and verify links still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)