### PR TITLE
fix: Run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,18 @@ FROM alpine:${ALPINEVERSION}
 # curl is required for healthchecks.
 RUN apk add --no-cache ca-certificates curl
 
+# Create non-root user
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
 WORKDIR /
 
 COPY --from=builder /app /app
 COPY config /config
+
+# Create writable directories for runtime data
+RUN mkdir -p /files && chown appuser:appgroup /files
+
+USER appuser
 
 EXPOSE 8080
 HEALTHCHECK CMD curl --fail http://localhost:8080 || exit 1


### PR DESCRIPTION
## Summary
- The Dockerfile did not define a non-privileged user, running the application as root inside the container
- Running as root increases the severity of any potential RCE or local file inclusion vulnerabilities
- Creates a dedicated `appuser:appgroup` and switches to it with `USER appuser`
- Creates a writable `/files` directory owned by the app user for file uploads

## Test plan
- [ ] Build and run the Docker container — verify the process runs as `appuser` (not root)
- [ ] Verify file uploads still work with the non-root user
- [ ] Verify healthcheck still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)