### PR TITLE
fix: Sanitize subject header in EmailMessenger to prevent injection

### DIFF
--- a/pkg/model/email.go
+++ b/pkg/model/email.go
@@ -30,8 +30,10 @@ func (m *EmailMessenger) sendMail(addr, from, subject, body string, to []string)
 
 	msg := "To: " + strings.Join(to, ",") + "\r\n" +
 		"From: " + from + "\r\n" +
-		"Subject: " + subject + "\r\n" +
-		strings.ReplaceAll(body, "Content-Type: text/plain", "Content-Type: text/plain; charset=UTF-8")
+		"Subject: " + r.Replace(subject) + "\r\n" +
+		"Content-Type: text/plain; charset=UTF-8\r\n" +
+		"\r\n" +
+		body
 	c, err := smtp.Dial(addr)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- The dormant `EmailMessenger.sendMail` in `pkg/model/email.go` did not sanitize the subject header through its CRLF replacer, allowing header injection if this code path is ever re-enabled
- The message was also missing the required `\r\n` separator between headers and body, and `Content-Type` was set via a fragile string replacement on the body content
- Applies the existing CRLF replacer to the subject, adds a proper `Content-Type` header, and fixes the header/body separator

## Test plan
- [ ] Code review: verify the subject is now passed through `r.Replace()`
- [ ] Code review: verify the CRLF separator between headers and body is present
- [ ] If EmailMessenger is enabled: verify emails are correctly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)